### PR TITLE
fix: Gemini 503 fallback for Terminal chat

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic';
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { getAllProjects } from '@/lib/storage';
-import { getGeminiClient, withRetry } from '@/lib/gemini';
+import { getGeminiClient, withRetry, isOverloaded } from '@/lib/gemini';
 import { mentorSystemPrompt, generateSuggestions, classifyChatProjectPrompt } from '@/lib/prompts';
 import {
   getConversationMessages,
@@ -116,11 +116,7 @@ export async function POST(request: NextRequest) {
     const client = getGeminiClient();
     const functionDeclarations = geminiFunctionDeclarations();
 
-    const model = client.getGenerativeModel({
-      model: 'gemini-2.5-flash',
-      systemInstruction: systemPrompt,
-      tools: [{ functionDeclarations }],
-    });
+    const CHAT_MODELS = ['gemini-2.5-flash', 'gemini-2.5-flash-lite'];
 
     const contents: Content[] = [
       ...(history ?? []).map<Content>((msg) => ({
@@ -139,15 +135,36 @@ export async function POST(request: NextRequest) {
         const emit = (s: string) => controller.enqueue(encoder.encode(s));
         let fullResponse = '';
 
+        let modelIndex = 0;
+        const getModel = () => client.getGenerativeModel({
+          model: CHAT_MODELS[modelIndex],
+          systemInstruction: systemPrompt,
+          tools: [{ functionDeclarations }],
+        });
+
+        const generateWithFallback = async (cts: Content[]) => {
+          while (true) {
+            try {
+              return await withRetry(() => getModel().generateContent({
+                contents: cts,
+                generationConfig: { temperature: 0.85, maxOutputTokens: 4096 },
+              }));
+            } catch (err) {
+              if (isOverloaded(err) && modelIndex < CHAT_MODELS.length - 1) {
+                modelIndex++;
+                continue;
+              }
+              throw err;
+            }
+          }
+        };
+
         try {
           let iterations = 0;
           while (iterations < MAX_TOOL_ITERATIONS) {
             iterations += 1;
 
-            const result = await withRetry(() => model.generateContent({
-              contents,
-              generationConfig: { temperature: 0.85, maxOutputTokens: 4096 },
-            }));
+            const result = await generateWithFallback(contents);
 
             const response = result.response;
             const calls = response.functionCalls() ?? [];
@@ -237,7 +254,7 @@ export async function POST(request: NextRequest) {
           if (currentProjectId === null && projects.length > 0) {
             try {
               const classifier = client.getGenerativeModel({
-                model: 'gemini-2.5-flash',
+                model: CHAT_MODELS[modelIndex],
                 generationConfig: { responseMimeType: 'application/json', temperature: 0 },
               });
               const res = await classifier.generateContent(

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -44,6 +44,8 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   });
 }
 
+export { isOverloaded };
+
 export async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {


### PR DESCRIPTION
## Summary
- When `gemini-2.5-flash` returns a 503 (high demand / service unavailable), the Terminal chat stream now automatically falls through to `gemini-2.5-flash-lite` instead of surfacing the raw error to the user
- `withRetry` still handles transient blips on each model before escalating to the next
- The post-stream classifier also inherits whichever model survived fallback
- Exports `isOverloaded` from `gemini.ts` so detection logic is shared (not duplicated)

## Test plan
- [ ] Open Terminal chat and send a message while primary model is overloaded — should get a response from the fallback model with no visible error
- [ ] Normal operation (no overload) still uses `gemini-2.5-flash`
- [ ] TypeScript: `npx tsc --noEmit` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)