### PR TITLE
fix: skip boot env validation during Next.js build phase

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -40,8 +40,10 @@ export function validateBootEnv(): void {
   if (bootValidated) return;
   bootValidated = true;
 
-  // In test/dev tooling we don't want this to throw — only enforce in prod.
+  // Skip in non-prod and during the Next.js build phase (page data collection
+  // runs before Vercel injects runtime env vars).
   if (process.env.NODE_ENV !== 'production') return;
+  if (process.env.NEXT_PHASE === 'phase-production-build') return;
 
   const missing = BOOT_REQUIRED.filter((key) => !process.env[key]);
   if (missing.length > 0) {


### PR DESCRIPTION
## Summary

- `validateBootEnv()` was throwing during Vercel's static page-data collection step because env vars aren't injected until runtime
- Added an early return when `NEXT_PHASE === 'phase-production-build'` so the check is skipped at build time but still enforced at runtime

## What changed

`src/lib/env.ts` — one extra guard in `validateBootEnv()`:

```ts
if (process.env.NEXT_PHASE === 'phase-production-build') return;
```

## Reviewer notes

The validation still runs in production at runtime (when env vars are available). This only skips the check during the Next.js build phase where Vercel hasn't yet injected the runtime secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)