### PR TITLE
perf: fix Supabase N+1 queries, add caching, new mentor chat on load

### DIFF
--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -17,7 +17,9 @@ export async function GET(request: NextRequest) {
   if (!role) return NextResponse.json({ error: 'Access denied' }, { status: 403 });
 
   const projects = await getAllProjects(teamId, session.user.id);
-  return NextResponse.json(projects);
+  return NextResponse.json(projects, {
+    headers: { 'Cache-Control': 'private, max-age=30, stale-while-revalidate=60' },
+  });
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/mentor/page.tsx
+++ b/src/app/mentor/page.tsx
@@ -125,7 +125,7 @@ export default function DashboardPage() {
   }, [currentTeam]);
 
   const refreshConversations = useCallback(async () => {
-    const res = await fetch('/api/chat/conversations?_t=' + Date.now(), { cache: 'no-store' });
+    const res = await fetch('/api/chat/conversations', { cache: 'no-store' });
     if (!res.ok) return [] as ChatConversation[];
     const data = await res.json() as { conversations: ChatConversation[] };
     setConversations(data.conversations ?? []);
@@ -169,12 +169,9 @@ export default function DashboardPage() {
       ]);
       if (cancelled) return;
       if (chatRes?.suggestions?.length > 0) setSuggestions(chatRes.suggestions);
-      if (convs.length > 0) {
-        await loadConversation(convs[0].id);
-      } else {
-        setActiveConvId(null);
-        setMessages([]);
-      }
+      // Always start with a blank new chat — previous conversations are accessible via ⌘K
+      setActiveConvId(null);
+      setMessages([]);
     })();
     return () => { cancelled = true; };
   }, [currentTeam, refreshConversations, loadConversation]);

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -10,6 +10,36 @@ function isMissingColumnError(error: unknown, column: string): boolean {
   );
 }
 
+// --- Next.js cache helpers (guarded for MCP server / test contexts) ---
+
+function tryRevalidate(...tags: string[]): void {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { revalidateTag } = require('next/cache') as { revalidateTag: (tag: string) => void };
+    tags.forEach(revalidateTag);
+  } catch {
+    // Not in a Next.js context (MCP server, tests) — safe to ignore
+  }
+}
+
+function cachedOr<R>(
+  fn: () => Promise<R>,
+  key: string[],
+  tags: string[],
+  revalidate = 60,
+): Promise<R> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { unstable_cache } = require('next/cache') as typeof import('next/cache');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (unstable_cache as any)(fn, key, { tags, revalidate })();
+  } catch {
+    return fn();
+  }
+}
+
+// -------------------------------------------------------------------
+
 export interface Project {
   id: string;
   teamId: string;
@@ -107,59 +137,73 @@ export interface FeedbackAnalysis {
   completedPrompts?: { promptIndex: number; completedAt: string; completedBy: string }[];
 }
 
-async function assembleProject(row: Record<string, unknown>): Promise<Project> {
-  const projectId = row.id as string;
+// Single embedded select that fetches all related rows in one HTTP request.
+// PostgREST follows FK relationships declared in the database schema.
+const PROJECT_SELECT = `
+  *,
+  project_analyses ( data, analyzed_at ),
+  marketing_content ( * ),
+  feedback_analyses ( * ),
+  campaigns ( * )
+`.trim();
 
-  // Fetch related data in parallel
-  const [analysisRes, marketingRes, feedbackRes, campaignsRes] = await Promise.all([
-    supabase.from('project_analyses').select('data, analyzed_at').eq('project_id', projectId).single(),
-    supabase.from('marketing_content').select('*').eq('project_id', projectId).order('generated_at', { ascending: false }),
-    supabase.from('feedback_analyses').select('*').eq('project_id', projectId).order('analyzed_at', { ascending: false }),
-    supabase.from('campaigns').select('*').eq('project_id', projectId).order('created_at', { ascending: false }),
-  ]);
+type EmbeddedRow = Record<string, unknown> & {
+  project_analyses: Array<{ data: unknown; analyzed_at: string }> | null;
+  marketing_content: Array<Record<string, unknown>> | null;
+  feedback_analyses: Array<Record<string, unknown>> | null;
+  campaigns: Array<Record<string, unknown>> | null;
+};
 
-  const analysis = analysisRes.data
-    ? { ...analysisRes.data.data as ProductAnalysis, analyzedAt: analysisRes.data.analyzed_at }
+function mapProjectRow(row: EmbeddedRow): Project {
+  const analysisArr = row.project_analyses;
+  const analysis: ProductAnalysis | undefined = analysisArr && analysisArr.length > 0
+    ? { ...(analysisArr[0].data as ProductAnalysis), analyzedAt: analysisArr[0].analyzed_at }
     : undefined;
 
-  const marketingContent: MarketingContent[] = (marketingRes.data ?? []).map((r) => ({
-    id: r.id,
-    platform: r.platform,
-    content: r.content as Record<string, string>,
-    generatedAt: r.generated_at,
-  }));
+  const marketingContent: MarketingContent[] = (row.marketing_content ?? [])
+    .map((r) => ({
+      id: r.id as string,
+      platform: r.platform as string,
+      content: r.content as Record<string, string>,
+      generatedAt: r.generated_at as string,
+    }))
+    .sort((a, b) => new Date(b.generatedAt).getTime() - new Date(a.generatedAt).getTime());
 
-  const feedbackAnalyses: FeedbackAnalysis[] = (feedbackRes.data ?? []).map((r) => ({
-    id: r.id,
-    rawFeedback: r.raw_feedback as string[],
-    sentiment: r.sentiment,
-    sentimentBreakdown: r.sentiment_breakdown as FeedbackAnalysis['sentimentBreakdown'],
-    themes: r.themes as string[],
-    featureRequests: r.feature_requests as string[],
-    bugs: r.bugs as string[],
-    praises: r.praises as string[],
-    developerPrompts: r.developer_prompts as string[],
-    analyzedAt: r.analyzed_at,
-    completedPrompts: (r.completed_prompts as FeedbackAnalysis['completedPrompts']) ?? [],
-  }));
+  const feedbackAnalyses: FeedbackAnalysis[] = (row.feedback_analyses ?? [])
+    .map((r) => ({
+      id: r.id as string,
+      rawFeedback: r.raw_feedback as string[],
+      sentiment: r.sentiment as string,
+      sentimentBreakdown: r.sentiment_breakdown as FeedbackAnalysis['sentimentBreakdown'],
+      themes: r.themes as string[],
+      featureRequests: r.feature_requests as string[],
+      bugs: r.bugs as string[],
+      praises: r.praises as string[],
+      developerPrompts: r.developer_prompts as string[],
+      analyzedAt: r.analyzed_at as string,
+      completedPrompts: (r.completed_prompts as FeedbackAnalysis['completedPrompts']) ?? [],
+    }))
+    .sort((a, b) => new Date(b.analyzedAt).getTime() - new Date(a.analyzedAt).getTime());
 
-  const campaigns: Campaign[] = (campaignsRes.data ?? []).map((r) => ({
-    id: r.id,
-    type: r.type,
-    goal: r.goal,
-    duration: r.duration,
-    name: r.name,
-    plan: r.plan as Record<string, unknown>,
-    createdAt: r.created_at,
-  }));
+  const campaigns: Campaign[] = (row.campaigns ?? [])
+    .map((r) => ({
+      id: r.id as string,
+      type: r.type as string,
+      goal: r.goal as string,
+      duration: r.duration as string,
+      name: r.name as string,
+      plan: r.plan as Record<string, unknown>,
+      createdAt: r.created_at as string,
+    }))
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
   return {
-    id: projectId,
+    id: row.id as string,
     teamId: row.team_id as string,
     createdBy: row.created_by as string,
     name: row.name as string,
     path: row.path as string | undefined,
-    sourceType: (row.source_type as string ?? 'codebase') as Project['sourceType'],
+    sourceType: ((row.source_type as string) ?? 'codebase') as Project['sourceType'],
     description: row.description as string | undefined,
     isGithub: row.is_github as boolean | undefined,
     githubUrl: row.github_url as string | undefined,
@@ -180,26 +224,23 @@ async function assembleProject(row: Record<string, unknown>): Promise<Project> {
  * shared projects are returned to all team members; unshared projects are
  * returned only to their creator. Pass the acting user's id to enforce this.
  */
-export async function getAllProjects(teamId: string, userId?: string): Promise<Project[]> {
-  let data: Record<string, unknown>[] | null;
+async function _getAllProjects(teamId: string, userId?: string): Promise<Project[]> {
+  let data: EmbeddedRow[] | null;
   let error: { message: string } | null;
 
+  const base = supabase
+    .from('projects')
+    .select(PROJECT_SELECT)
+    .eq('team_id', teamId)
+    .order('created_at', { ascending: false });
+
   if (userId) {
-    const result = await supabase
-      .from('projects')
-      .select('*')
-      .eq('team_id', teamId)
-      .order('created_at', { ascending: false })
-      .or(`is_shared.eq.true,created_by.eq.${userId}`);
-    data = result.data;
+    const result = await base.or(`is_shared.eq.true,created_by.eq.${userId}`);
+    data = result.data as unknown as EmbeddedRow[] | null;
     error = result.error;
   } else {
-    const result = await supabase
-      .from('projects')
-      .select('*')
-      .eq('team_id', teamId)
-      .order('created_at', { ascending: false });
-    data = result.data;
+    const result = await base;
+    data = result.data as unknown as EmbeddedRow[] | null;
     error = result.error;
   }
 
@@ -207,30 +248,46 @@ export async function getAllProjects(teamId: string, userId?: string): Promise<P
   if (error && isMissingColumnError(error, 'is_shared')) {
     const fallback = await supabase
       .from('projects')
-      .select('*')
+      .select(PROJECT_SELECT)
       .eq('team_id', teamId)
       .order('created_at', { ascending: false });
-    data = fallback.data;
+    data = fallback.data as unknown as EmbeddedRow[] | null;
     error = fallback.error;
   }
 
   if (error) throw new Error(`Failed to list projects: ${error.message}`);
-
   if (!data || data.length === 0) return [];
-  return Promise.all(data.map((row) => assembleProject(row)));
+  return data.map(mapProjectRow);
 }
 
-export async function getProject(id: string, teamId: string, userId?: string): Promise<Project | undefined> {
+export function getAllProjects(teamId: string, userId?: string): Promise<Project[]> {
+  return cachedOr(
+    () => _getAllProjects(teamId, userId),
+    ['getAllProjects', teamId, userId ?? 'anon'],
+    [`team:${teamId}`],
+  );
+}
+
+async function _getProject(id: string, teamId: string, userId?: string): Promise<Project | undefined> {
   const { data } = await supabase
     .from('projects')
-    .select('*')
+    .select(PROJECT_SELECT)
     .eq('id', id)
     .eq('team_id', teamId)
     .single();
   if (!data) return undefined;
+  const row = data as unknown as EmbeddedRow;
   // Enforce privacy: unshared project only visible to creator.
-  if (userId && data.is_shared === false && data.created_by !== userId) return undefined;
-  return assembleProject(data);
+  if (userId && row.is_shared === false && row.created_by !== userId) return undefined;
+  return mapProjectRow(row);
+}
+
+export function getProject(id: string, teamId: string, userId?: string): Promise<Project | undefined> {
+  return cachedOr(
+    () => _getProject(id, teamId, userId),
+    ['getProject', id, teamId, userId ?? 'anon'],
+    [`project:${id}`, `team:${teamId}`],
+  );
 }
 
 export async function updateProjectShared(
@@ -246,6 +303,7 @@ export async function updateProjectShared(
     .eq('id', projectId)
     .eq('team_id', teamId)
     .eq('created_by', userId);
+  if (!error) tryRevalidate(`project:${projectId}`, `team:${teamId}`);
   return !error;
 }
 
@@ -271,12 +329,12 @@ export async function getProjectForTeams(id: string, teamIds: string[]): Promise
   if (teamIds.length === 0) return undefined;
   const { data } = await supabase
     .from('projects')
-    .select('*')
+    .select(PROJECT_SELECT)
     .eq('id', id)
     .in('team_id', teamIds)
     .single();
   if (!data) return undefined;
-  return assembleProject(data);
+  return mapProjectRow(data as unknown as EmbeddedRow);
 }
 
 export async function saveProject(project: Project): Promise<void> {
@@ -372,10 +430,13 @@ export async function saveProject(project: Project): Promise<void> {
     }));
     await supabase.from('campaigns').upsert(rows);
   }
+
+  tryRevalidate(`team:${core.teamId}`, `project:${core.id}`);
 }
 
 export async function deleteProject(id: string, teamId: string): Promise<void> {
   await supabase.from('projects').delete().eq('id', id).eq('team_id', teamId);
+  tryRevalidate(`team:${teamId}`, `project:${id}`);
 }
 
 export async function saveCampaignToProject(projectId: string, campaign: Campaign, teamId: string): Promise<boolean> {
@@ -392,6 +453,7 @@ export async function saveCampaignToProject(projectId: string, campaign: Campaig
     plan: campaign.plan,
     created_at: campaign.createdAt,
   });
+  if (!error) tryRevalidate(`team:${teamId}`, `project:${projectId}`);
   return !error;
 }
 
@@ -405,6 +467,7 @@ export async function saveSocialProfilesToProject(
     .update({ social_profiles: profiles })
     .eq('id', projectId)
     .eq('team_id', teamId);
+  if (!error) tryRevalidate(`project:${projectId}`);
   return !error;
 }
 
@@ -418,6 +481,7 @@ export async function updateProjectAnalyticsProperty(
     .update({ analytics_property_id: analyticsPropertyId })
     .eq('id', projectId)
     .eq('team_id', teamId);
+  if (!error) tryRevalidate(`project:${projectId}`);
   return !error;
 }
 
@@ -438,6 +502,7 @@ export async function saveFeedbackToProject(projectId: string, analysis: Feedbac
     developer_prompts: analysis.developerPrompts,
     analyzed_at: analysis.analyzedAt,
   });
+  if (!error) tryRevalidate(`team:${teamId}`, `project:${projectId}`);
   return !error;
 }
 


### PR DESCRIPTION
## Summary

- **N+1 fix**: `assembleProject()` previously fired 4 parallel Supabase HTTP requests per project (analyses, marketing, feedback, campaigns). `getAllProjects` then fanned that out across all projects, producing `1 + 4N` round-trips. Replaced with a single PostgREST embedded select — regardless of project count, one request does it all.
- **Caching layer**: `getAllProjects` and `getProject` are now wrapped in Next.js `unstable_cache` (60s TTL, per-team tags). Warm-instance reads skip Supabase entirely. Every mutation (`saveProject`, `deleteProject`, feedback, campaigns, etc.) calls `revalidateTag` so the cache busts immediately on writes. Both helpers are guarded with try/catch so the MCP server process (no `next/cache`) keeps working.
- **HTTP cache**: Added `Cache-Control: private, max-age=30, stale-while-revalidate=60` to `GET /api/projects` so repeat browser navigations within 30s skip the network.
- **Mentor page UX**: Page now starts in a blank new chat instead of auto-loading the previous conversation. The old behaviour caused Supabase fetch latency (~2s) to pop old messages into the input area mid-typing. Previous chats remain accessible via ⌘K.
- **Cleanup**: Removed `?_t=Date.now()` cache-busting params from the mentor page's chat API fetches (redundant alongside `cache: 'no-store'`).

## Files changed

| File | Change |
|---|---|
| `src/lib/storage.ts` | Core rewrite — embedded select, `mapProjectRow`, `cachedOr`, `tryRevalidate`, cache invalidation on all mutations |
| `src/app/mentor/page.tsx` | Start blank on load; remove `_t` cache-busting |
| `src/app/api/projects/route.ts` | Add `Cache-Control` header to GET response |

## Test plan

- [ ] Load a page with multiple projects — check Supabase Dashboard > Logs > API shows a single request instead of 5+
- [ ] Navigate to the same project list twice within 60s — second load should produce no Supabase API calls
- [ ] Create/delete a project — verify it appears/disappears immediately (cache invalidated)
- [ ] Open `/mentor` — verify it starts with a blank chat, not the previous conversation
- [ ] Check DevTools Network: `/api/chat/conversations` URL no longer contains `?_t=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)