### PR TITLE
fix: drop unstable_cache from project reads

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -10,36 +10,6 @@ function isMissingColumnError(error: unknown, column: string): boolean {
   );
 }
 
-// --- Next.js cache helpers (guarded for MCP server / test contexts) ---
-
-function tryRevalidate(...tags: string[]): void {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { revalidateTag } = require('next/cache') as { revalidateTag: (tag: string) => void };
-    tags.forEach(revalidateTag);
-  } catch {
-    // Not in a Next.js context (MCP server, tests) — safe to ignore
-  }
-}
-
-function cachedOr<R>(
-  fn: () => Promise<R>,
-  key: string[],
-  tags: string[],
-  revalidate = 60,
-): Promise<R> {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { unstable_cache } = require('next/cache') as typeof import('next/cache');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (unstable_cache as any)(fn, key, { tags, revalidate })();
-  } catch {
-    return fn();
-  }
-}
-
-// -------------------------------------------------------------------
-
 export interface Project {
   id: string;
   teamId: string;
@@ -247,11 +217,7 @@ async function _getAllProjects(teamId: string, userId?: string): Promise<Project
 }
 
 export function getAllProjects(teamId: string, userId?: string): Promise<Project[]> {
-  return cachedOr(
-    () => _getAllProjects(teamId, userId),
-    ['getAllProjects', teamId, userId ?? 'anon'],
-    [`team:${teamId}`],
-  );
+  return _getAllProjects(teamId, userId);
 }
 
 async function _getProject(id: string, teamId: string, userId?: string): Promise<Project | undefined> {
@@ -268,11 +234,7 @@ async function _getProject(id: string, teamId: string, userId?: string): Promise
 }
 
 export function getProject(id: string, teamId: string, userId?: string): Promise<Project | undefined> {
-  return cachedOr(
-    () => _getProject(id, teamId, userId),
-    ['getProject', id, teamId, userId ?? 'anon'],
-    [`project:${id}`, `team:${teamId}`],
-  );
+  return _getProject(id, teamId, userId);
 }
 
 export async function updateProjectShared(
@@ -288,7 +250,6 @@ export async function updateProjectShared(
     .eq('id', projectId)
     .eq('team_id', teamId)
     .eq('created_by', userId);
-  if (!error) tryRevalidate(`project:${projectId}`, `team:${teamId}`);
   return !error;
 }
 
@@ -415,13 +376,10 @@ export async function saveProject(project: Project): Promise<void> {
     }));
     await supabase.from('campaigns').upsert(rows);
   }
-
-  tryRevalidate(`team:${core.teamId}`, `project:${core.id}`);
 }
 
 export async function deleteProject(id: string, teamId: string): Promise<void> {
   await supabase.from('projects').delete().eq('id', id).eq('team_id', teamId);
-  tryRevalidate(`team:${teamId}`, `project:${id}`);
 }
 
 export async function saveCampaignToProject(projectId: string, campaign: Campaign, teamId: string): Promise<boolean> {
@@ -438,7 +396,6 @@ export async function saveCampaignToProject(projectId: string, campaign: Campaig
     plan: campaign.plan,
     created_at: campaign.createdAt,
   });
-  if (!error) tryRevalidate(`team:${teamId}`, `project:${projectId}`);
   return !error;
 }
 
@@ -452,7 +409,6 @@ export async function saveSocialProfilesToProject(
     .update({ social_profiles: profiles })
     .eq('id', projectId)
     .eq('team_id', teamId);
-  if (!error) tryRevalidate(`project:${projectId}`);
   return !error;
 }
 
@@ -466,7 +422,6 @@ export async function updateProjectAnalyticsProperty(
     .update({ analytics_property_id: analyticsPropertyId })
     .eq('id', projectId)
     .eq('team_id', teamId);
-  if (!error) tryRevalidate(`project:${projectId}`);
   return !error;
 }
 
@@ -487,7 +442,6 @@ export async function saveFeedbackToProject(projectId: string, analysis: Feedbac
     developer_prompts: analysis.developerPrompts,
     analyzed_at: analysis.analyzedAt,
   });
-  if (!error) tryRevalidate(`team:${teamId}`, `project:${projectId}`);
   return !error;
 }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -137,68 +137,55 @@ export interface FeedbackAnalysis {
   completedPrompts?: { promptIndex: number; completedAt: string; completedBy: string }[];
 }
 
-// Single embedded select that fetches all related rows in one HTTP request.
-// PostgREST follows FK relationships declared in the database schema.
-const PROJECT_SELECT = `
-  *,
-  project_analyses ( data, analyzed_at ),
-  marketing_content ( * ),
-  feedback_analyses ( * ),
-  campaigns ( * )
-`.trim();
+type ProjectRow = Record<string, unknown>;
 
-type EmbeddedRow = Record<string, unknown> & {
-  project_analyses: Array<{ data: unknown; analyzed_at: string }> | null;
-  marketing_content: Array<Record<string, unknown>> | null;
-  feedback_analyses: Array<Record<string, unknown>> | null;
-  campaigns: Array<Record<string, unknown>> | null;
-};
+async function assembleProject(row: ProjectRow): Promise<Project> {
+  const projectId = row.id as string;
 
-function mapProjectRow(row: EmbeddedRow): Project {
-  const analysisArr = row.project_analyses;
-  const analysis: ProductAnalysis | undefined = analysisArr && analysisArr.length > 0
-    ? { ...(analysisArr[0].data as ProductAnalysis), analyzedAt: analysisArr[0].analyzed_at }
+  const [analysisRes, marketingRes, feedbackRes, campaignsRes] = await Promise.all([
+    supabase.from('project_analyses').select('data, analyzed_at').eq('project_id', projectId).maybeSingle(),
+    supabase.from('marketing_content').select('*').eq('project_id', projectId).order('generated_at', { ascending: false }),
+    supabase.from('feedback_analyses').select('*').eq('project_id', projectId).order('analyzed_at', { ascending: false }),
+    supabase.from('campaigns').select('*').eq('project_id', projectId).order('created_at', { ascending: false }),
+  ]);
+
+  const analysis: ProductAnalysis | undefined = analysisRes.data
+    ? { ...(analysisRes.data.data as ProductAnalysis), analyzedAt: analysisRes.data.analyzed_at as string }
     : undefined;
 
-  const marketingContent: MarketingContent[] = (row.marketing_content ?? [])
-    .map((r) => ({
-      id: r.id as string,
-      platform: r.platform as string,
-      content: r.content as Record<string, string>,
-      generatedAt: r.generated_at as string,
-    }))
-    .sort((a, b) => new Date(b.generatedAt).getTime() - new Date(a.generatedAt).getTime());
+  const marketingContent: MarketingContent[] = (marketingRes.data ?? []).map((r: Record<string, unknown>) => ({
+    id: r.id as string,
+    platform: r.platform as string,
+    content: r.content as Record<string, string>,
+    generatedAt: r.generated_at as string,
+  }));
 
-  const feedbackAnalyses: FeedbackAnalysis[] = (row.feedback_analyses ?? [])
-    .map((r) => ({
-      id: r.id as string,
-      rawFeedback: r.raw_feedback as string[],
-      sentiment: r.sentiment as string,
-      sentimentBreakdown: r.sentiment_breakdown as FeedbackAnalysis['sentimentBreakdown'],
-      themes: r.themes as string[],
-      featureRequests: r.feature_requests as string[],
-      bugs: r.bugs as string[],
-      praises: r.praises as string[],
-      developerPrompts: r.developer_prompts as string[],
-      analyzedAt: r.analyzed_at as string,
-      completedPrompts: (r.completed_prompts as FeedbackAnalysis['completedPrompts']) ?? [],
-    }))
-    .sort((a, b) => new Date(b.analyzedAt).getTime() - new Date(a.analyzedAt).getTime());
+  const feedbackAnalyses: FeedbackAnalysis[] = (feedbackRes.data ?? []).map((r: Record<string, unknown>) => ({
+    id: r.id as string,
+    rawFeedback: r.raw_feedback as string[],
+    sentiment: r.sentiment as string,
+    sentimentBreakdown: r.sentiment_breakdown as FeedbackAnalysis['sentimentBreakdown'],
+    themes: r.themes as string[],
+    featureRequests: r.feature_requests as string[],
+    bugs: r.bugs as string[],
+    praises: r.praises as string[],
+    developerPrompts: r.developer_prompts as string[],
+    analyzedAt: r.analyzed_at as string,
+    completedPrompts: (r.completed_prompts as FeedbackAnalysis['completedPrompts']) ?? [],
+  }));
 
-  const campaigns: Campaign[] = (row.campaigns ?? [])
-    .map((r) => ({
-      id: r.id as string,
-      type: r.type as string,
-      goal: r.goal as string,
-      duration: r.duration as string,
-      name: r.name as string,
-      plan: r.plan as Record<string, unknown>,
-      createdAt: r.created_at as string,
-    }))
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  const campaigns: Campaign[] = (campaignsRes.data ?? []).map((r: Record<string, unknown>) => ({
+    id: r.id as string,
+    type: r.type as string,
+    goal: r.goal as string,
+    duration: r.duration as string,
+    name: r.name as string,
+    plan: r.plan as Record<string, unknown>,
+    createdAt: r.created_at as string,
+  }));
 
   return {
-    id: row.id as string,
+    id: projectId,
     teamId: row.team_id as string,
     createdBy: row.created_by as string,
     name: row.name as string,
@@ -225,39 +212,38 @@ function mapProjectRow(row: EmbeddedRow): Project {
  * returned only to their creator. Pass the acting user's id to enforce this.
  */
 async function _getAllProjects(teamId: string, userId?: string): Promise<Project[]> {
-  let data: EmbeddedRow[] | null;
+  let data: ProjectRow[] | null;
   let error: { message: string } | null;
 
   const base = supabase
     .from('projects')
-    .select(PROJECT_SELECT)
+    .select('*')
     .eq('team_id', teamId)
     .order('created_at', { ascending: false });
 
   if (userId) {
     const result = await base.or(`is_shared.eq.true,created_by.eq.${userId}`);
-    data = result.data as unknown as EmbeddedRow[] | null;
+    data = result.data as ProjectRow[] | null;
     error = result.error;
   } else {
     const result = await base;
-    data = result.data as unknown as EmbeddedRow[] | null;
+    data = result.data as ProjectRow[] | null;
     error = result.error;
   }
 
-  // Backward-compatibility for databases that haven't added projects.is_shared yet.
   if (error && isMissingColumnError(error, 'is_shared')) {
     const fallback = await supabase
       .from('projects')
-      .select(PROJECT_SELECT)
+      .select('*')
       .eq('team_id', teamId)
       .order('created_at', { ascending: false });
-    data = fallback.data as unknown as EmbeddedRow[] | null;
+    data = fallback.data as ProjectRow[] | null;
     error = fallback.error;
   }
 
   if (error) throw new Error(`Failed to list projects: ${error.message}`);
   if (!data || data.length === 0) return [];
-  return data.map(mapProjectRow);
+  return Promise.all(data.map(assembleProject));
 }
 
 export function getAllProjects(teamId: string, userId?: string): Promise<Project[]> {
@@ -271,15 +257,14 @@ export function getAllProjects(teamId: string, userId?: string): Promise<Project
 async function _getProject(id: string, teamId: string, userId?: string): Promise<Project | undefined> {
   const { data } = await supabase
     .from('projects')
-    .select(PROJECT_SELECT)
+    .select('*')
     .eq('id', id)
     .eq('team_id', teamId)
     .single();
   if (!data) return undefined;
-  const row = data as unknown as EmbeddedRow;
-  // Enforce privacy: unshared project only visible to creator.
+  const row = data as ProjectRow;
   if (userId && row.is_shared === false && row.created_by !== userId) return undefined;
-  return mapProjectRow(row);
+  return assembleProject(row);
 }
 
 export function getProject(id: string, teamId: string, userId?: string): Promise<Project | undefined> {
@@ -329,12 +314,12 @@ export async function getProjectForTeams(id: string, teamIds: string[]): Promise
   if (teamIds.length === 0) return undefined;
   const { data } = await supabase
     .from('projects')
-    .select(PROJECT_SELECT)
+    .select('*')
     .eq('id', id)
     .in('team_id', teamIds)
     .single();
   if (!data) return undefined;
-  return mapProjectRow(data as unknown as EmbeddedRow);
+  return assembleProject(data as ProjectRow);
 }
 
 export async function saveProject(project: Project): Promise<void> {


### PR DESCRIPTION
## Summary
- Analyses saved correctly but UI showed projects as "pending" — `unstable_cache` was returning stale Project objects with `analysis` missing.
- Removes the `cachedOr` wrapper from `getAllProjects` / `getProject` so reads always hit Supabase (4 parallel queries per project, same as pre-cache baseline).
- Removes now-dead `tryRevalidate` calls from the mutation helpers.

## Test plan
- [ ] Open /projects on production after deploy — analyzed projects show the "analyzed" tag and description/tech-stack.
- [ ] Running a fresh analysis updates the card immediately on next load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)